### PR TITLE
Add wrapset - template-wrapper for memset

### DIFF
--- a/emb/pastilda/app/app.cpp
+++ b/emb/pastilda/app/app.cpp
@@ -21,6 +21,7 @@
 
 #include "app.h"
 #include "stdio.h"
+#include "wrapset.h"
 using namespace Application;
 
 App *app_pointer;
@@ -50,7 +51,7 @@ void App::redirect(uint8_t *data, uint8_t len)
 
 void App::control_interception()
 {
-	memset(app_pointer->key, 0, 8);
+	ZeroIt(app_pointer->key);
 	app_pointer->key[2] = KEY_W;
 	app_pointer->key[3] = KEY_O;
 	app_pointer->key[4] = KEY_N;

--- a/emb/pastilda/app/wrapset.h
+++ b/emb/pastilda/app/wrapset.h
@@ -1,0 +1,7 @@
+#ifndef __WRAPSET__
+#define __WRAPSET__
+template<typename T> void ZeroIt(T& value)
+{
+    memset(&value,0,sizeof(value));
+}
+#endif


### PR DESCRIPTION
Использование такой оберки вокруг **memset** позволяет обезопасить себя от стрельбы по конечностям.
